### PR TITLE
Rename libs' plugins

### DIFF
--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -1,15 +1,21 @@
-import jest from './jest';
-import prettier from './prettier';
-import react from './react';
-import reactHooks from './react-hooks';
-import typescript from './typescript';
+import jestLib from './jest';
+import prettierLib from './prettier';
+import reactLib from './react';
+import reactHooksLib from './react-hooks';
+import typescriptLib from './typescript';
 
-export const list = [jest, prettier, react, reactHooks, typescript];
+export const list = [
+  jestLib,
+  prettierLib,
+  reactLib,
+  reactHooksLib,
+  typescriptLib,
+];
 
 export default {
-  jest,
-  prettier,
-  react,
-  reactHooks,
-  typescript,
+  jest: jestLib,
+  prettier: prettierLib,
+  react: reactLib,
+  reactHooks: reactHooksLib,
+  typescript: typescriptLib,
 };

--- a/src/lib/plugins/jest.ts
+++ b/src/lib/plugins/jest.ts
@@ -3,7 +3,7 @@ import { LibraryConfig } from '../interfaces/library-config';
 /**
  * https://www.npmjs.com/package/eslint-plugin-jest
  */
-export const jest: LibraryConfig = {
+export const jestLib: LibraryConfig = {
   name: 'Jest',
   order: 'normal',
   plugins: ['jest'],
@@ -11,4 +11,4 @@ export const jest: LibraryConfig = {
   dependencies: ['eslint-plugin-jest'],
 };
 
-export default jest;
+export default jestLib;

--- a/src/lib/plugins/prettier.ts
+++ b/src/lib/plugins/prettier.ts
@@ -3,7 +3,7 @@ import { LibraryConfig } from '../interfaces/library-config';
 /**
  * https://www.npmjs.com/package/eslint-config-prettier
  */
-export const prettier: LibraryConfig = {
+export const prettierLib: LibraryConfig = {
   name: 'Prettier',
   order: 'late',
   plugins: [],
@@ -17,4 +17,4 @@ export const prettier: LibraryConfig = {
   dependencies: ['eslint-config-prettier'],
 };
 
-export default prettier;
+export default prettierLib;

--- a/src/lib/plugins/react-hooks.ts
+++ b/src/lib/plugins/react-hooks.ts
@@ -3,7 +3,7 @@ import { LibraryConfig } from '../interfaces/library-config';
 /**
  * https://www.npmjs.com/package/eslint-plugin-react-hooks
  */
-export const reactHooks: LibraryConfig = {
+export const reactHooksLib: LibraryConfig = {
   name: 'React-Hooks',
   order: 'normal',
   plugins: ['react-hooks'],
@@ -11,4 +11,4 @@ export const reactHooks: LibraryConfig = {
   dependencies: ['eslint-plugin-react-hooks'],
 };
 
-export default reactHooks;
+export default reactHooksLib;

--- a/src/lib/plugins/react.ts
+++ b/src/lib/plugins/react.ts
@@ -3,7 +3,7 @@ import { LibraryConfig } from '../interfaces/library-config';
 /**
  * https://www.npmjs.com/package/eslint-plugin-react
  */
-export const react: LibraryConfig = {
+export const reactLib: LibraryConfig = {
   name: 'React',
   order: 'normal',
   plugins: ['react'],
@@ -11,4 +11,4 @@ export const react: LibraryConfig = {
   dependencies: ['eslint-plugin-react'],
 };
 
-export default react;
+export default reactLib;

--- a/src/lib/plugins/typescript.ts
+++ b/src/lib/plugins/typescript.ts
@@ -3,7 +3,7 @@ import { LibraryConfig } from '../interfaces/library-config';
 /**
  * https://www.npmjs.com/package/@typescript-eslint/eslint-plugin
  */
-export const typescript: LibraryConfig = {
+export const typescriptLib: LibraryConfig = {
   name: 'Typescript',
   order: 'normal',
   plugins: ['@typescript-eslint'],
@@ -15,4 +15,4 @@ export const typescript: LibraryConfig = {
   ],
 };
 
-export default typescript;
+export default typescriptLib;


### PR DESCRIPTION
Due to `jest` tests complaining with `Identifier 'jest' has already been declared` on the `jest` file exporting it.