### PR TITLE
Add CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2.1
+orbs:
+  node: circleci/node@3.0.0
+workflows:
+  node-tests:
+    jobs:
+      - node/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,19 @@
-version: 2.1
+jobs:
+  test:
+    executor:
+      name: node/default
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          command: yarn run test
+          name: Run YARN tests
+
 orbs:
-  node: circleci/node@3.0.0
+  node: circleci/node@4.0.1
+version: 2.1
 workflows:
-  node-tests:
+  ci-tests:
     jobs:
-      - node/test
+      - test


### PR DESCRIPTION
This will allow us to automatically run our tests, linting, and other scripts on PRs. The CI jobs must pass (complete successfully) for the PR to be closable. This will help us enfore better code quality and prepare us to open up the project to community contributors.

This PR originally suggested using CircleCI but we have decided to evaluate using [LGTM](lgtm.com) instead.

(For those at 3ap; CircleCI is the CI tool we usually use at work.)