### PR TITLE
Add `basename` to router for fixing root `/` matching

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_ROUTER_BASENAME="/ezlint"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Router>
+      <Router basename={process.env.REACT_APP_ROUTER_BASENAME}>
         {/* import other stuff here */}
         <Layout>
           <Switch>


### PR DESCRIPTION
Using the `.env` file we add a `basename` to the `react-router` in order
to match correctly the homepage URL and render the app correctly. This
is because our "production" hosting is GitHub pages which has the root
starting from `<github url>/ezlint` rather than `<github url>/`.
